### PR TITLE
Adding Dockerfile for easier deployment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python
+LABEL MAINTAINER "Ayush Priya"
+
+RUN apt-get update && apt-get install git -y \
+    && git clone https://github.com/mzfr/liffy \
+    && cd liffy \
+    && pip install -r requirements.txt \
+    && wget https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb \
+    && chmod +x msfupdate.erb \
+    && ./msfupdate.erb 
+
+WORKDIR /liffy
+
+ENTRYPOINT ["python", "/liffy/liffy.py"]
+
+CMD ["--help"]


### PR DESCRIPTION
Added a Dockerfile to build and run liffy without having to set up an environment. Didn't add docker build and run instructions as there's already a wiki setup which can be edited to have a ".. with Docker" section.